### PR TITLE
Fix a compilation error on MacOS BigSur 11.2

### DIFF
--- a/src/clistats.cpp
+++ b/src/clistats.cpp
@@ -402,22 +402,6 @@ public:
     }
 
     /**
-     * Convert string to template type value
-     * @param[in] index Token index
-     * @param[out] dst Destination value
-     * @return True if parsing successful otherwise false
-     * @throws std::runtime_error if unable to parse string
-     */
-    template <class T>
-    T
-    toValue(size_type index) const
-    {
-        T & dst = NULL;
-        bool isGood = this->toValue<T>(this->at(index), dst);
-        if (!isGood) throw std::runtime_error("Unable to parse string = " + this->at(index));
-    }
-    
-    /**
      * Convert string to range of integers. Expected format is
      * "A:B". If a range is found (e.g., 3:5) then the array
      * of numbers from the first to the second are returned

--- a/src/clistats.cpp
+++ b/src/clistats.cpp
@@ -412,7 +412,7 @@ public:
     T
     toValue(size_type index) const
     {
-        T & dst;
+        T & dst = NULL;
         bool isGood = this->toValue<T>(this->at(index), dst);
         if (!isGood) throw std::runtime_error("Unable to parse string = " + this->at(index));
     }


### PR DESCRIPTION
Setting `dst` to `NULL` fixes the compilation error - seems valid
because whilst `toValue` seems to want to output into `dst` (I'm
guessing that `>> NULL` just acts as a sink?), it's never actually
used here and we're only interested in the boolean return.

(no idea about fixing the warning, tho', sorry)
```
> make
g++ -O2 src/clistats.cpp -o clistats
src/clistats.cpp:194:46: warning: result of comparison of constant 18446744073709551615 with expression of type 'unsigned int' is always true
      [-Wtautological-constant-out-of-range-compare]
        while((pos = content.find(src, pos)) != std::string::npos)
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~
src/clistats.cpp:415:13: error: declaration of reference variable 'dst' requires an initializer
        T & dst;
            ^~~
1 warning and 1 error generated.
make: *** [clistats] Error 1
```

```
> g++ -v
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: x86_64-apple-darwin20.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```